### PR TITLE
Rounding FUISwitch thumbEdgeSize calculation

### DIFF
--- a/Classes/ios/FUISwitch.m
+++ b/Classes/ios/FUISwitch.m
@@ -85,7 +85,7 @@
     
     //thumb image
     CGFloat insetFraction = .75;
-    CGFloat thumbEdgeSize = contentHeight * insetFraction;
+    CGFloat thumbEdgeSize = floorf(contentHeight * insetFraction);
     CGFloat thumbInset = (contentHeight - thumbEdgeSize) / 2;
     self.thumbView.frame = CGRectMake((self.internalContainer.contentSize.width - contentHeight) / 2 + thumbInset, thumbInset, thumbEdgeSize, thumbEdgeSize);
     self.thumbView.layer.cornerRadius = thumbEdgeSize / 2;


### PR DESCRIPTION
Rounds down the thumbEdgeSize using floorf. Which without, you can see the rendering issue:

![screen shot 2013-05-17 at 21 50 31](https://f.cloud.github.com/assets/608543/520404/9889d7bc-bf37-11e2-812f-e4ced33a7dba.png)
