### PR TITLE
Updated UIColor+FlatUI.h to declare colorFromHexCode

### DIFF
--- a/Classes/ios/UIColor+FlatUI.h
+++ b/Classes/ios/UIColor+FlatUI.h
@@ -10,6 +10,7 @@
 
 @interface UIColor (FlatUI)
 
++ (UIColor *) colorFromHexCode:(NSString *)hexString;
 + (UIColor *) turquoiseColor;
 + (UIColor *) greenSeaColor;
 + (UIColor *) emerlandColor;


### PR DESCRIPTION
A small thing, but I find it useful to have this class method declared in the header file. I find my self using it by itself very frequently. I understand if you're trying to push for using named color methods instead, though.
