### PR TITLE
Bug with selected background view in grouped tableview.

### DIFF
--- a/Classes/ios/UITableViewCell+FlatUI.m
+++ b/Classes/ios/UITableViewCell+FlatUI.m
@@ -43,7 +43,6 @@
 
 - (void)setCornerRadius:(CGFloat)cornerRadius {
     [(FUICellBackgroundView*)self.backgroundView setCornerRadius:cornerRadius];
-    [(FUICellBackgroundView*)self.selectedBackgroundView setCornerRadius:cornerRadius];
 }
 
 - (void)setSeparatorHeight:(CGFloat)separatorHeight {


### PR DESCRIPTION
If set new corner radius to selected background view it will be little smaller than background view. And colored corners will be visible, when select as show on screenshot.
![cell_selected_background_view](https://f.cloud.github.com/assets/3592457/694664/3f7dbcbe-dcb6-11e2-8e2d-ae82c2f12506.png)
