### PR TITLE
Fix Warning for edgeSizeFromCornerRadius

### DIFF
--- a/Classes/ios/UIImage+FlatUI.m
+++ b/Classes/ios/UIImage+FlatUI.m
@@ -10,7 +10,7 @@
 
 @implementation UIImage (FlatUI)
 
-CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
+static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     return cornerRadius * 2 + 1;
 }
 


### PR DESCRIPTION
This fixes the warning
UIImage+FlatUI.m:13:9: No previous prototype for function 'edgeSizeFromCornerRadius'
