### PR TITLE
[FIX] Default UISwitch behaviour for FUISwitch

### DIFF
--- a/Classes/ios/FUISwitch.m
+++ b/Classes/ios/FUISwitch.m
@@ -104,9 +104,15 @@
 }
 
 - (void)setOn:(BOOL)on animated:(BOOL)animated {
+    [self setOn:on animated:NO sendEvent:NO];
+}
+
+- (void)setOn:(BOOL)on animated:(BOOL)animated sendEvent:(BOOL)sendEvent {
     if (_on != on) {
         _on = on;
-        [self sendActionsForControlEvents:UIControlEventValueChanged];
+        if (sendEvent) {
+            [self sendActionsForControlEvents:UIControlEventValueChanged];
+        }
     }
     [self setPercentOn:_on * 1.0f animated:animated];
 }
@@ -141,13 +147,13 @@
     }
     else if (gestureRecognizer.state == UIGestureRecognizerStateEnded) {
         BOOL left = newOffset.x > maxOffset / 2;
-        [self setOn:(!left) animated:YES];
+        [self setOn:(!left) animated:YES sendEvent:YES];
     }
     
 }
 
 - (void) tapped:(UITapGestureRecognizer *)gestureRecognizer {
-    [self setOn:!self.on animated:YES];
+    [self setOn:!self.on animated:YES sendEvent:YES];
 }
 
 - (void) setOnBackgroundColor:(UIColor *)onBackgroundColor {


### PR DESCRIPTION
Just added a `setOn:animated:sendEvent:` private method to mimic the default functionality of `UISwitch`. Events will be sent only when tapping or panning.
