### PR TITLE
Fix sometime FUISwitch just show only with a background view.

### DIFF
--- a/Classes/ios/FUISwitch.m
+++ b/Classes/ios/FUISwitch.m
@@ -114,7 +114,7 @@
             [self sendActionsForControlEvents:UIControlEventValueChanged];
         }
     }
-    [self setPercentOn:_on * 1.0f animated:animated];
+    [self setPercentOn:[NSNumber numberWithBool:_on].integerValue * 1.0f animated:animated];
 }
 
 - (void) setPercentOn:(CGFloat)percentOn {


### PR DESCRIPTION
Sometime the switch appear just with a background view, I am using Apple LLVM compile 4.2. But after I changed boolean to a NSNumber object, it works well.
