### PR TITLE
code review:  iOS 7 style back button for iOS 5 + 6

### DIFF
--- a/Classes/ios/FlatUIKit.h
+++ b/Classes/ios/FlatUIKit.h
@@ -26,6 +26,7 @@
 #import "FUISegmentedControl.h"
 #import "FUISwitch.h"
 #import "UIBarButtonItem+FlatUI.h"
+#import "UIBarButtonItem+FlatUI_iOS7_BackButton.h"
 #import "UIColor+FlatUI.h"
 #import "UIFont+FlatUI.h"
 #import "UIImage+FlatUI.h"

--- a/Classes/ios/UIBarButtonItem+FlatUI.h
+++ b/Classes/ios/UIBarButtonItem+FlatUI.h
@@ -37,37 +37,4 @@
           removeShadow:(BOOL) aRemoveShadow;
 
 
-#pragma mark - iOS Style Back Button for iOS 5 + 6
-
-/**
- returns an iOS 7 style bar button item (blue cheveron)
- 
- should only be used on iOS < 7 (use the iOS 7 default if you want iOS 7 look and feel)
- 
- @param aChevronColorNil color of the chevron; if nil is set to Apple iOS 7 blue
- @return a bar button item with no title in the style of iOS 7
- */
-+ (UIBarButtonItem *) barButtonItem_iOS7_styleWithChevronColor:(UIColor *) aChevronColorOrNil;
-
-
-/**
- returns an iOS 7 style bar button item (blue cheveron)
- 
- should only be used on iOS < 7 (use the iOS 7 default if you want iOS 7 look and feel)
- 
- NB: shadows are removed from the title
- 
- @param aTitleOrNil title of button; if nil then it will default to 'Back' in (like iOS 7)
- @param aChevronColorNil color of the chevron; if nil is set to Apple iOS 7 blue
- @param aTitleColorOrNil color of title in control state normal; if nil defaults
- to blue and if title is nil, this is ignored
- @param aHighlightedColorOrNil color of title in control state highlighted; if nil defaults
- to white and if title is nil, this is ignored
- @return a bar button item in the style of iOS 7
- */
-+ (UIBarButtonItem *) barButtonItem_iOS7_styleWithTitle:(NSString *) aTitleOrNil
-                                           chevronColor:(UIColor *) aChevronColorOrNil
-                                             titleColor:(UIColor *) aTitleColorOrNil
-                                       highlightedColor:(UIColor *) aHighlightedColorOrNil;
-
 @end

--- a/Classes/ios/UIBarButtonItem+FlatUI.m
+++ b/Classes/ios/UIBarButtonItem+FlatUI.m
@@ -9,164 +9,55 @@
 #import "UIBarButtonItem+FlatUI.h"
 #import "UIImage+FlatUI.h"
 
-/**** DEBUG *****
- 
- i did not want to expose the
- 
- backButtonImageWith_iOS7_style_WithColor: barMetrics: 
- 
- in the UIImage category, but needed this to demonstrate the clipping problem
- with an opaque fill
- ****************/
- 
-@interface UIImage (FlatKit)
-
-// suppresses compiler warnings
-+ (UIBezierPath *) bezierPathForBackButtonInRect:(CGRect)rect cornerRadius:(CGFloat)radius;
-
-@end
- 
-/*********************/
-@interface UIImage (FlatKit_UIBarButtonItem_iOS7)
-
-/**
- @return returns an iOS 7 style cheveron back button
- @param aColor the color of the chevron
- @param aMetric the bar metrics
- */
-+ (UIImage *) backButtonImageWith_iOS7_style_WithChevronColor:(UIColor *) aColor
-                                                   barMetrics:(UIBarMetrics) aMetrics;
-
-
-
-@end
-
-
-@implementation UIImage (FlatKit_UIBarButtonItem_iOS7)
-
-+ (UIImage *) backButtonImageWith_iOS7_style_WithChevronColor:(UIColor *) aColor
-                                                   barMetrics:(UIBarMetrics) aMetrics {
-    // changing the width does not help with the clipping problem
-    CGSize size = aMetrics == UIBarMetricsDefault ? CGSizeMake(50, 30) : CGSizeMake(60, 23);
-    
-    
-    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0f);
-    
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    
-    CGContextSetStrokeColorWithColor(context, aColor.CGColor);
-    CGContextSetLineWidth(context, 2.5f);
-    
-    /*** UNEXPECTED *****
-     
-     - not tested on portrait rotation (non-default bar metrics)
-     
-     *******************/
-     // matches nicely, but causes text clipping
-    static CGFloat const k_tip_x = 8;
-    static CGFloat const k_wing_x = 16;
-    static CGFloat const k_wing_y_offset = 6;
-
-    /*
-     // does not match so nicely, but kinda sorta fixes text clipping
-    static CGFloat const k_tip_x = 2;
-    static CGFloat const k_wing_x = 10;
-    static CGFloat const k_wing_y_offset = 6;
-     */
-    CGRect rect = CGRectMake(0, 0, size.width, size.height);
-    CGPoint tip = CGPointMake(k_tip_x, CGRectGetMidY(rect));
-    CGPoint top = CGPointMake(k_wing_x, CGRectGetMinY(rect) + k_wing_y_offset);
-    CGPoint bottom = CGPointMake(k_wing_x, CGRectGetMaxY(rect) - k_wing_y_offset);
-    CGContextMoveToPoint(context, top.x, top.y);
-    CGContextAddLineToPoint(context, tip.x, tip.y);
-    CGContextAddLineToPoint(context, bottom.x, bottom.y);
-    CGContextStrokePath(context);
- 
-    /**** DEBUG *****/
-    // uncomment to see the clipping
-    /*
-    UIBezierPath *path = [self bezierPathForBackButtonInRect:CGRectMake(0, 0, size.width, size.height)
-                                                    cornerRadius:0.0];
-
-    [[UIColor lightGrayColor] setFill];
-    [path addClip];
-    [path fill];
-    */
-    
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
-    // can something be done with the edge insets
-    return [image resizableImageWithCapInsets:UIEdgeInsetsMake(0, 0, 0, 0)
-                                 resizingMode:UIImageResizingModeStretch];
-}
-
-@end
-
-
-// private
-@interface UIBarButtonItem (FlatKit)
-
-+ (UIColor *) iOS7_blueColor;
-+ (UIFont *) iOS7_navbarFont;
-
-+ (void) configure_iOS7_style_BackButtonItemOrProxy:(id)appearance
-                                  withCheveronColor:(UIColor *) aCheveronColor;
-
-- (void) setTitleFont:(UIFont *) aTitleFont;
-
-
-@end
-
 
 @implementation UIBarButtonItem (FlatUI)
 
 - (void) configureFlatButtonWithColor:(UIColor *)color
                      highlightedColor:(UIColor *)highlightedColor
                          cornerRadius:(CGFloat) cornerRadius {
-  
-  [UIBarButtonItem configureItemOrProxy:self forFlatButtonWithColor:color highlightedColor:highlightedColor cornerRadius:cornerRadius];
-  
+    
+    [UIBarButtonItem configureItemOrProxy:self forFlatButtonWithColor:color highlightedColor:highlightedColor cornerRadius:cornerRadius];
+    
 }
 
 + (void) configureFlatButtonsWithColor:(UIColor *) color
                       highlightedColor:(UIColor *)highlightedColor
                           cornerRadius:(CGFloat) cornerRadius {
-  
-  [self configureFlatButtonsWithColor:color highlightedColor:highlightedColor cornerRadius:cornerRadius whenContainedIn:[UINavigationBar class], [UINavigationController class], [UIToolbar class], nil];
+    
+    [self configureFlatButtonsWithColor:color highlightedColor:highlightedColor cornerRadius:cornerRadius whenContainedIn:[UINavigationBar class], [UINavigationController class], [UIToolbar class], nil];
 }
 
 + (void) configureFlatButtonsWithColor:(UIColor *) color
                       highlightedColor:(UIColor *)highlightedColor
                           cornerRadius:(CGFloat) cornerRadius
                        whenContainedIn:(Class <UIAppearanceContainer>)containerClass, ... {
-  va_list vl;
-  va_start(vl, containerClass);
-  id appearance = [UIBarButtonItem appearanceWhenContainedIn:containerClass, nil];
-  va_end(vl);
-  [UIBarButtonItem configureItemOrProxy:appearance forFlatButtonWithColor:color highlightedColor:highlightedColor cornerRadius:cornerRadius];
+    va_list vl;
+    va_start(vl, containerClass);
+    id appearance = [UIBarButtonItem appearanceWhenContainedIn:containerClass, nil];
+    va_end(vl);
+    [UIBarButtonItem configureItemOrProxy:appearance forFlatButtonWithColor:color highlightedColor:highlightedColor cornerRadius:cornerRadius];
 }
 
 
 - (void) removeTitleShadow {
-  NSArray *states = @[@(UIControlStateNormal), @(UIControlStateHighlighted)];
-  
-  for (NSNumber *state in states) {
-    UIControlState controlState = [state unsignedIntegerValue];
-    NSMutableDictionary *titleTextAttributes = [[self titleTextAttributesForState:controlState] mutableCopy];
-    if (!titleTextAttributes) {
-      titleTextAttributes = [NSMutableDictionary dictionary];
+    NSArray *states = @[@(UIControlStateNormal), @(UIControlStateHighlighted)];
+    
+    for (NSNumber *state in states) {
+        UIControlState controlState = [state unsignedIntegerValue];
+        NSMutableDictionary *titleTextAttributes = [[self titleTextAttributesForState:controlState] mutableCopy];
+        if (!titleTextAttributes) {
+            titleTextAttributes = [NSMutableDictionary dictionary];
+        }
+        
+        /*** UNEXPECTED ***
+         UITextAttributeShadowOffset is deprecated in 5.0 - replaced with NSShadow
+         - tried using NSShadow, but the shadow on the title remained
+         - shadowOffset <== {0,0}, shadowColor <== nil (shadow not drawn according to docs)
+         ******************/
+        [titleTextAttributes setValue:[NSValue valueWithUIOffset:UIOffsetZero] forKey:UITextAttributeTextShadowOffset];
+        [titleTextAttributes setObject:[UIColor clearColor] forKey:UITextAttributeTextShadowColor];
+        [self setTitleTextAttributes:titleTextAttributes forState:controlState];
     }
-
-    /*** UNEXPECTED ***
-     UITextAttributeShadowOffset is deprecated in 5.0 - replaced with NSShadow
-     - tried using NSShadow, but the shadow on the title remained
-     - shadowOffset <== {0,0}, shadowColor <== nil (shadow not drawn according to docs)
-     ******************/
-    [titleTextAttributes setValue:[NSValue valueWithUIOffset:UIOffsetZero] forKey:UITextAttributeTextShadowOffset];
-    [titleTextAttributes setObject:[UIColor clearColor] forKey:UITextAttributeTextShadowColor];
-    [self setTitleTextAttributes:titleTextAttributes forState:controlState];
-  }
 }
 
 - (void) setTitleColor:(UIColor *) aColor
@@ -192,180 +83,41 @@
        forFlatButtonWithColor:(UIColor *)color
              highlightedColor:(UIColor *)highlightedColor
                  cornerRadius:(CGFloat) cornerRadius {
-  UIImage *backButtonPortraitImage = [UIImage backButtonImageWithColor:color
-                                                            barMetrics:UIBarMetricsDefault
-                                                          cornerRadius:cornerRadius];
-  UIImage *highlightedBackButtonPortraitImage = [UIImage backButtonImageWithColor:highlightedColor
-                                                                       barMetrics:UIBarMetricsDefault
-                                                                     cornerRadius:cornerRadius];
-  UIImage *backButtonLandscapeImage = [UIImage backButtonImageWithColor:color
-                                                             barMetrics:UIBarMetricsLandscapePhone
-                                                           cornerRadius:2];
-  UIImage *highlightedBackButtonLandscapeImage = [UIImage backButtonImageWithColor:highlightedColor
-                                                                        barMetrics:UIBarMetricsLandscapePhone
-                                                                      cornerRadius:2];
-  
-  [appearance setBackButtonBackgroundImage:backButtonPortraitImage
-                                  forState:UIControlStateNormal
-                                barMetrics:UIBarMetricsDefault];
-  [appearance setBackButtonBackgroundImage:backButtonLandscapeImage
-                                  forState:UIControlStateNormal
-                                barMetrics:UIBarMetricsLandscapePhone];
-  [appearance setBackButtonBackgroundImage:highlightedBackButtonPortraitImage
-                                  forState:UIControlStateHighlighted
-                                barMetrics:UIBarMetricsDefault];
-  [appearance setBackButtonBackgroundImage:highlightedBackButtonLandscapeImage
-                                  forState:UIControlStateHighlighted
-                                barMetrics:UIBarMetricsLandscapePhone];
-  
-  [appearance setBackButtonTitlePositionAdjustment:UIOffsetMake(1.0f, 1.0f) forBarMetrics:UIBarMetricsDefault];
-  [appearance setBackButtonTitlePositionAdjustment:UIOffsetMake(1.0f, 1.0f) forBarMetrics:UIBarMetricsLandscapePhone];
-  
-  UIImage *buttonImageNormal       = [UIImage imageWithColor:color cornerRadius:cornerRadius];
-  UIImage *buttonImageHightlighted = [UIImage imageWithColor:highlightedColor cornerRadius:cornerRadius];
-  [appearance setBackgroundImage:buttonImageNormal forState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
-  [appearance setBackgroundImage:buttonImageHightlighted forState:UIControlStateHighlighted barMetrics:UIBarMetricsDefault];
-}
-
-
-#pragma mark - iOS Style Back Button for iOS 5 + 6
-
-+ (UIColor *) iOS7_blueColor {
-    static UIColor *ios7_blue_singleton = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        ios7_blue_singleton = [UIColor colorWithRed:0/255.0f green:122/255.0f blue:245/255.0f alpha:1.0f];
-    });
-
-    return ios7_blue_singleton;
-}
-
-+ (UIFont *) iOS7_navbarFont {
-    static UIFont *ios7_navbar_font_singleton = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        static NSString *const fontName = @"HelveticaNeue-Light";
-        ios7_navbar_font_singleton = [UIFont fontWithName:fontName size:17];
-    });
-    return ios7_navbar_font_singleton;
-}
-
-- (void) setTitleFont:(UIFont *) aTitleFont {
-    NSArray *states = @[@(UIControlStateNormal), @(UIControlStateHighlighted)];
-    for (NSNumber *state in states) {
-        UIControlState controlState = [state unsignedIntegerValue];
-        NSMutableDictionary *titleTextAttributes = [[self titleTextAttributesForState:controlState] mutableCopy];
-        if (!titleTextAttributes) {
-            titleTextAttributes = [NSMutableDictionary dictionary];
-        }
-        
-        /*** UNEXPECTED ***
-         UITextAttributeShadowOffset is deprecated in 5.0 - replaced with NSFontAttributeName
-         - tried using NSFontAttributeName but the font does not change
-         ******************/
-        [titleTextAttributes setObject:aTitleFont forKey:UITextAttributeFont];
-        [self setTitleTextAttributes:titleTextAttributes forState:controlState];
-    }
-}
-
-+ (void) configure_iOS7_style_BackButtonItemOrProxy:(id)appearance
-                                  withCheveronColor:(UIColor *) aCheveronColor {
+    UIImage *backButtonPortraitImage = [UIImage backButtonImageWithColor:color
+                                                              barMetrics:UIBarMetricsDefault
+                                                            cornerRadius:cornerRadius];
+    UIImage *highlightedBackButtonPortraitImage = [UIImage backButtonImageWithColor:highlightedColor
+                                                                         barMetrics:UIBarMetricsDefault
+                                                                       cornerRadius:cornerRadius];
+    UIImage *backButtonLandscapeImage = [UIImage backButtonImageWithColor:color
+                                                               barMetrics:UIBarMetricsLandscapePhone
+                                                             cornerRadius:2];
+    UIImage *highlightedBackButtonLandscapeImage = [UIImage backButtonImageWithColor:highlightedColor
+                                                                          barMetrics:UIBarMetricsLandscapePhone
+                                                                        cornerRadius:2];
     
-    // normal and highlighted are the same
-    UIImage *metricsDefaultImage = [UIImage backButtonImageWith_iOS7_style_WithChevronColor:aCheveronColor
-                                                                           barMetrics:UIBarMetricsDefault];
-    UIImage *metricsLandscapeImage =  [UIImage backButtonImageWith_iOS7_style_WithChevronColor:aCheveronColor
-                                                                               barMetrics:UIBarMetricsLandscapePhone];
-
-    
-    [appearance setBackButtonBackgroundImage:metricsDefaultImage
+    [appearance setBackButtonBackgroundImage:backButtonPortraitImage
                                     forState:UIControlStateNormal
                                   barMetrics:UIBarMetricsDefault];
-    [appearance setBackButtonBackgroundImage:metricsLandscapeImage
+    [appearance setBackButtonBackgroundImage:backButtonLandscapeImage
                                     forState:UIControlStateNormal
                                   barMetrics:UIBarMetricsLandscapePhone];
-    [appearance setBackButtonBackgroundImage:metricsDefaultImage
+    [appearance setBackButtonBackgroundImage:highlightedBackButtonPortraitImage
                                     forState:UIControlStateHighlighted
                                   barMetrics:UIBarMetricsDefault];
-    [appearance setBackButtonBackgroundImage:metricsLandscapeImage
+    [appearance setBackButtonBackgroundImage:highlightedBackButtonLandscapeImage
                                     forState:UIControlStateHighlighted
                                   barMetrics:UIBarMetricsLandscapePhone];
     
-    [appearance setBackButtonTitlePositionAdjustment:UIOffsetMake(6.0f, -3.0f) forBarMetrics:UIBarMetricsDefault];
-    [appearance setBackButtonTitlePositionAdjustment:UIOffsetMake(6.0f, -3.0f) forBarMetrics:UIBarMetricsLandscapePhone];
-
-    /*
-     unnecessary ?
-    UIImage *buttonImageNormal       = [UIImage imageWithColor:aCheveronColor cornerRadius:cornerRadius];
+    [appearance setBackButtonTitlePositionAdjustment:UIOffsetMake(1.0f, 1.0f) forBarMetrics:UIBarMetricsDefault];
+    [appearance setBackButtonTitlePositionAdjustment:UIOffsetMake(1.0f, 1.0f) forBarMetrics:UIBarMetricsLandscapePhone];
+    
+    UIImage *buttonImageNormal       = [UIImage imageWithColor:color cornerRadius:cornerRadius];
     UIImage *buttonImageHightlighted = [UIImage imageWithColor:highlightedColor cornerRadius:cornerRadius];
     [appearance setBackgroundImage:buttonImageNormal forState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
     [appearance setBackgroundImage:buttonImageHightlighted forState:UIControlStateHighlighted barMetrics:UIBarMetricsDefault];
-     */
-
 }
 
-
-+ (UIBarButtonItem *) barButtonItem_iOS7_styleWithChevronColor:(UIColor *) aChevronColorOrNil {
-    UIBarButtonItem *back = [[UIBarButtonItem alloc]
-                             // will be hidden
-                             initWithTitle:@"back"
-                             // plain or bordered does not matter
-                             style:UIBarButtonItemStylePlain
-                             target:nil
-                             action:nil];
-    
-    
-    
-    UIColor *color = aChevronColorOrNil ? aChevronColorOrNil : [UIBarButtonItem iOS7_blueColor];
-        
-    [UIBarButtonItem configure_iOS7_style_BackButtonItemOrProxy:back withCheveronColor:color];
-    
-    // hide the text
-    // maybe we should pass the navbar color?
-    UIColor *clear = [UIColor clearColor];
-    [back setTitleColor:clear highlighted:clear removeShadow:YES];
-
-    
-    return back;
-}
-
-
-+ (UIBarButtonItem *) barButtonItem_iOS7_styleWithTitle:(NSString *) aTitleOrNil
-                                           chevronColor:(UIColor *) aChevronColorOrNil
-                                             titleColor:(UIColor *) aTitleColorOrNil
-                                       highlightedColor:(UIColor *) aHighlightedColorOrNil {
-    
-    // we need a non-zero length title or the button will not appear
-    // in iOS 7 the default title is "Back" (i think.)
-    NSString *title = aTitleOrNil;
-    if (title == nil || [title length] == 0) {
-        title = NSLocalizedString(@"Back", @"bar button title: touching brings you back to where you where");
-    }
-    
-    UIBarButtonItem *back = [[UIBarButtonItem alloc]
-                             // will be hidden
-                             initWithTitle:title
-                             // plain or bordered does not matter
-                             style:UIBarButtonItemStylePlain
-                             target:nil
-                             action:nil];
-
-    
-    UIColor *ios7_blue = [UIBarButtonItem iOS7_blueColor];
-    UIColor *chevronColor = aChevronColorOrNil ? aChevronColorOrNil : ios7_blue;
-
-    [UIBarButtonItem configure_iOS7_style_BackButtonItemOrProxy:back withCheveronColor:chevronColor];
-    
-    // on iOS 7 it looks like the highlight color is a transparency of the title color
-    UIColor *titleColor = aTitleColorOrNil ? aTitleColorOrNil : ios7_blue;
-    UIColor *highlightColor = aHighlightedColorOrNil ? aHighlightedColorOrNil : [titleColor colorWithAlphaComponent:0.5f];
-    
-
-    [back setTitleColor:titleColor highlighted:highlightColor removeShadow:YES];
-    [back setTitleFont:[UIBarButtonItem iOS7_navbarFont]];
-
-    return back;
-}
 
 
 @end

--- a/Classes/ios/UIBarButtonItem+FlatUI_iOS7_BackButton.h
+++ b/Classes/ios/UIBarButtonItem+FlatUI_iOS7_BackButton.h
@@ -1,0 +1,46 @@
+//
+//  UIBarButtonItem+FlatUI.h
+//  FlatUI
+//
+//  Created by Jack Flintermann on 5/8/13.
+//  Copyright (c) 2013 Jack Flintermann. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIBarButtonItem (FlatUI_iOS7_BackButton)
+
+#pragma mark - iOS Style Back Button for iOS 5 + 6
+
+/**
+ returns an iOS 7 style bar button item (blue cheveron)
+ 
+ should only be used on iOS < 7 (use the iOS 7 default if you want iOS 7 look and feel)
+ 
+ @param aChevronColorNil color of the chevron; if nil is set to Apple iOS 7 blue
+ @return a bar button item with no title in the style of iOS 7
+ */
++ (UIBarButtonItem *) barButtonItem_iOS7_styleWithChevronColor:(UIColor *) aChevronColorOrNil;
+
+
+/**
+ returns an iOS 7 style bar button item (blue cheveron)
+ 
+ should only be used on iOS < 7 (use the iOS 7 default if you want iOS 7 look and feel)
+ 
+ NB: shadows are removed from the title
+ 
+ @param aTitleOrNil title of button; if nil then it will default to 'Back' in (like iOS 7)
+ @param aChevronColorNil color of the chevron; if nil is set to Apple iOS 7 blue
+ @param aTitleColorOrNil color of title in control state normal; if nil defaults
+ to blue and if title is nil, this is ignored
+ @param aHighlightedColorOrNil color of title in control state highlighted; if nil defaults
+ to white and if title is nil, this is ignored
+ @return a bar button item in the style of iOS 7
+ */
++ (UIBarButtonItem *) barButtonItem_iOS7_styleWithTitle:(NSString *) aTitleOrNil
+                                           chevronColor:(UIColor *) aChevronColorOrNil
+                                             titleColor:(UIColor *) aTitleColorOrNil
+                                       highlightedColor:(UIColor *) aHighlightedColorOrNil;
+
+@end

--- a/Classes/ios/UIBarButtonItem+FlatUI_iOS7_BackButton.m
+++ b/Classes/ios/UIBarButtonItem+FlatUI_iOS7_BackButton.m
@@ -1,0 +1,233 @@
+//
+//  UIBarButtonItem+FlatUI.m
+//  FlatUI
+//
+//  Created by Jack Flintermann on 5/8/13.
+//  Copyright (c) 2013 Jack Flintermann. All rights reserved.
+//
+
+#import "UIBarButtonItem+FlatUI_iOS7_BackButton.h"
+#import "UIImage+FlatUI.h"
+
+/*** UNEXPECTED ****
+ 
+ - not sure where the maintainer wants this method
+ 
+ *******************/
+
+@interface UIImage (FlatKit_UIBarButtonItem_iOS7_BackButton)
+
+/**
+ @return returns an iOS 7 style cheveron back button
+ @param aColor the color of the chevron
+ @param aMetric the bar metrics
+ */
++ (UIImage *) backButtonImageWith_iOS7_style_WithChevronColor:(UIColor *) aColor
+                                                   barMetrics:(UIBarMetrics) aMetrics;
+
+
+
+@end
+
+
+@implementation UIImage (FlatKit_UIBarButtonItem_iOS7_BackButton)
+
++ (UIImage *) backButtonImageWith_iOS7_style_WithChevronColor:(UIColor *) aColor
+                                                   barMetrics:(UIBarMetrics) aMetrics {
+    CGSize size = aMetrics == UIBarMetricsDefault ? CGSizeMake(50, 30) : CGSizeMake(60, 23);
+    
+    
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0f);
+    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextSetStrokeColorWithColor(context, aColor.CGColor);
+    CGContextSetLineWidth(context, 3.0f);
+    
+    /*** UNEXPECTED *****
+     
+     - not tested on portrait rotation (non-default bar metrics)
+     
+     *******************/
+    
+    static CGFloat const k_tip_x = 6;
+    static CGFloat const k_wing_x = 14;
+    static CGFloat const k_wing_y_offset = 6;
+    
+    CGRect rect = CGRectMake(0, 0, size.width, size.height);
+    CGPoint tip = CGPointMake(k_tip_x, CGRectGetMidY(rect));
+    CGPoint top = CGPointMake(k_wing_x, CGRectGetMinY(rect) + k_wing_y_offset);
+    CGPoint bottom = CGPointMake(k_wing_x, CGRectGetMaxY(rect) - k_wing_y_offset);
+    CGContextMoveToPoint(context, top.x, top.y);
+    CGContextAddLineToPoint(context, tip.x, tip.y);
+    CGContextAddLineToPoint(context, bottom.x, bottom.y);
+    CGContextStrokePath(context);
+    
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    // avoid tiling by stretching from the right-hand side only
+    UIEdgeInsets insets = UIEdgeInsetsMake(k_wing_y_offset + 1, k_wing_x + 1,
+                                           k_wing_y_offset + 1, 1);
+    if ([image respondsToSelector:@selector(resizableImageWithCapInsets:resizingMode:)]) {
+        return [image resizableImageWithCapInsets:insets
+                                     resizingMode:UIImageResizingModeStretch];
+    } else {
+        return [image resizableImageWithCapInsets:insets];
+    }
+}
+
+@end
+
+
+@interface UIBarButtonItem (FlatUI_iOS7_BackButton_PRIVATE)
+
++ (UIColor *) colorFor_iOS7_BackButton;
++ (UIFont *) fontFor_iOS7_BackButton;
+
++ (void) configure_iOS7_style_BackButtonItemOrProxy:(id)appearance
+                                  withCheveronColor:(UIColor *) aCheveronColor;
+
+- (void) setTitleFont_iOS7_BackButton:(UIFont *) aTitleFont;
+
+
+@end
+
+
+@implementation UIBarButtonItem (FlatUI_iOS7_BackButton)
+
+
+
+#pragma mark - iOS Style Back Button for iOS 5 + 6
+
++ (UIColor *)  colorFor_iOS7_BackButton {
+    static UIColor *ios7_blue_singleton = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        ios7_blue_singleton = [UIColor colorWithRed:0/255.0f green:122/255.0f blue:245/255.0f alpha:1.0f];
+    });
+    
+    return ios7_blue_singleton;
+}
+
++ (UIFont *) fontFor_iOS7_BackButton {
+    // font is not quiet right
+    static UIFont *ios7_navbar_font_singleton = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        static NSString *const fontName = @"HelveticaNeue";
+        ios7_navbar_font_singleton = [UIFont fontWithName:fontName size:17];
+    });
+    return ios7_navbar_font_singleton;
+}
+
+- (void) setTitleFont_iOS7_BackButton:(UIFont *) aTitleFont {
+    NSArray *states = @[@(UIControlStateNormal), @(UIControlStateHighlighted)];
+    for (NSNumber *state in states) {
+        UIControlState controlState = [state unsignedIntegerValue];
+        NSMutableDictionary *titleTextAttributes = [[self titleTextAttributesForState:controlState] mutableCopy];
+        if (!titleTextAttributes) {
+            titleTextAttributes = [NSMutableDictionary dictionary];
+        }
+        
+        /*** UNEXPECTED ***
+         UITextAttributeShadowOffset is deprecated in 5.0 - replaced with NSFontAttributeName
+         - tried using NSFontAttributeName but the font does not change
+         ******************/
+        [titleTextAttributes setObject:aTitleFont forKey:UITextAttributeFont];
+        [self setTitleTextAttributes:titleTextAttributes forState:controlState];
+    }
+}
+
++ (void) configure_iOS7_style_BackButtonItemOrProxy:(id)appearance
+                                  withCheveronColor:(UIColor *) aCheveronColor {
+    
+    // normal and highlighted are the same
+    UIImage *metricsDefaultImage = [UIImage backButtonImageWith_iOS7_style_WithChevronColor:aCheveronColor
+                                                                                 barMetrics:UIBarMetricsDefault];
+    UIImage *metricsLandscapeImage =  [UIImage backButtonImageWith_iOS7_style_WithChevronColor:aCheveronColor
+                                                                                    barMetrics:UIBarMetricsLandscapePhone];
+    
+    
+    [appearance setBackButtonBackgroundImage:metricsDefaultImage
+                                    forState:UIControlStateNormal
+                                  barMetrics:UIBarMetricsDefault];
+    [appearance setBackButtonBackgroundImage:metricsLandscapeImage
+                                    forState:UIControlStateNormal
+                                  barMetrics:UIBarMetricsLandscapePhone];
+    [appearance setBackButtonBackgroundImage:metricsDefaultImage
+                                    forState:UIControlStateHighlighted
+                                  barMetrics:UIBarMetricsDefault];
+    [appearance setBackButtonBackgroundImage:metricsLandscapeImage
+                                    forState:UIControlStateHighlighted
+                                  barMetrics:UIBarMetricsLandscapePhone];
+    
+    [appearance setBackButtonTitlePositionAdjustment:UIOffsetMake(6.0f, -3.0f) forBarMetrics:UIBarMetricsDefault];
+    [appearance setBackButtonTitlePositionAdjustment:UIOffsetMake(6.0f, -3.0f) forBarMetrics:UIBarMetricsLandscapePhone];
+    
+}
+
++ (UIBarButtonItem *) barButtonItem_iOS7_styleWithChevronColor:(UIColor *) aChevronColorOrNil {
+    UIBarButtonItem *back = [[UIBarButtonItem alloc]
+                             // will be hidden
+                             initWithTitle:@"back"
+                             // plain or bordered does not matter
+                             style:UIBarButtonItemStylePlain
+                             target:nil
+                             action:nil];
+    
+    
+    
+    UIColor *color = aChevronColorOrNil ? aChevronColorOrNil : [UIBarButtonItem colorFor_iOS7_BackButton];
+    
+    [UIBarButtonItem configure_iOS7_style_BackButtonItemOrProxy:back withCheveronColor:color];
+    
+    // hide the text
+    // maybe we should pass the navbar color?
+    UIColor *clear = [UIColor clearColor];
+    [back setTitleColor:clear highlighted:clear removeShadow:YES];
+    
+    
+    return back;
+}
+
+
++ (UIBarButtonItem *) barButtonItem_iOS7_styleWithTitle:(NSString *) aTitleOrNil
+                                           chevronColor:(UIColor *) aChevronColorOrNil
+                                             titleColor:(UIColor *) aTitleColorOrNil
+                                       highlightedColor:(UIColor *) aHighlightedColorOrNil {
+    
+    // we need a non-zero length title or the button will not appear (iirc)
+    // in iOS 7 the default title is "Back" (i think.)
+    NSString *title = aTitleOrNil;
+    if (title == nil || [title length] == 0) {
+        title = NSLocalizedString(@"Back", @"bar button title: touching brings you back to where you where");
+    }
+    
+    UIBarButtonItem *back = [[UIBarButtonItem alloc]
+                             // will be hidden
+                             initWithTitle:title
+                             // plain or bordered does not matter
+                             style:UIBarButtonItemStylePlain
+                             target:nil
+                             action:nil];
+    
+    
+    UIColor *ios7_blue = [UIBarButtonItem colorFor_iOS7_BackButton];
+    UIColor *chevronColor = aChevronColorOrNil ? aChevronColorOrNil : ios7_blue;
+    
+    [UIBarButtonItem configure_iOS7_style_BackButtonItemOrProxy:back withCheveronColor:chevronColor];
+    
+    // on iOS 7 it looks like the highlight color is a transparency of the title color
+    UIColor *titleColor = aTitleColorOrNil ? aTitleColorOrNil : ios7_blue;
+    UIColor *highlightColor = aHighlightedColorOrNil ? aHighlightedColorOrNil : [titleColor colorWithAlphaComponent:0.5f];
+    
+    
+    [back setTitleColor:titleColor highlighted:highlightColor removeShadow:YES];
+    [back setTitleFont_iOS7_BackButton:[UIBarButtonItem fontFor_iOS7_BackButton]];
+    
+    return back;
+}
+
+
+@end

--- a/Classes/ios/UIImage+FlatUI.m
+++ b/Classes/ios/UIImage+FlatUI.m
@@ -128,10 +128,14 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     CGContextSetStrokeColorWithColor(context, [UIColor colorWithR:0 g:122 b:245].CGColor);
     CGContextSetLineWidth(context, 3.0f);
     
+    static CGFloat const k_tip_x = 8;
+    static CGFloat const k_wing_x = 17;
+    static CGFloat const k_wing_y_offset = 6;
+    
     CGRect rect = CGRectMake(0, 0, size.width, size.height);
-    CGPoint tip = CGPointMake(8, CGRectGetMidY(rect));
-    CGPoint top = CGPointMake(13 + 4, CGRectGetMinY(rect) + 6);
-    CGPoint bottom = CGPointMake(13 + 4, CGRectGetMaxY(rect) - 6);
+    CGPoint tip = CGPointMake(k_tip_x, CGRectGetMidY(rect));
+    CGPoint top = CGPointMake(k_wing_x, CGRectGetMinY(rect) + k_wing_y_offset);
+    CGPoint bottom = CGPointMake(k_wing_x, CGRectGetMaxY(rect) - k_wing_y_offset);
     CGContextMoveToPoint(context, top.x, top.y);
     CGContextAddLineToPoint(context, tip.x, tip.y);
     CGContextAddLineToPoint(context, bottom.x, bottom.y);
@@ -143,8 +147,18 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
-    return [image resizableImageWithCapInsets:UIEdgeInsetsMake(cornerRadius, 0, cornerRadius, cornerRadius)];
     
+    // avoid tiling by stretching from the right-hand side only
+    UIEdgeInsets insets = UIEdgeInsetsMake(k_wing_y_offset + 1 + cornerRadius, k_wing_x + 1 + cornerRadius,
+                                           k_wing_y_offset + 1 + cornerRadius, 1 + cornerRadius);
+    if ([image respondsToSelector:@selector(resizableImageWithCapInsets:resizingMode:)]) {
+        return [image resizableImageWithCapInsets:insets
+                                     resizingMode:UIImageResizingModeStretch];
+        
+    } else {
+        return [image resizableImageWithCapInsets:insets];
+    }
+
 }
 
 


### PR DESCRIPTION
IMPORTANT: this is not a request to merge, but a request for a code review

i am working on an iOS 7 treatment for one of my apps and I am trying to replicate the iOS 7 (navigation) bar button item in iOS 5 + 6.

working from the code in FlatKit, i was able to make a lot of progress, but i am stuck on a problem that my drawing and layout foo is not strong enough to solve.

i am wondering if someone (or several someone's) would be willing to do an old fashioned code review and work with me to solve this problem.

as you can see from the screenshot, i am having trouble with the borders of the button clipping the right-hand side of the text.  

i could move the text over to left and solve the problem for short titles like 'Back', but i would like a general solution (and one that matches the iOS 7 layout).

anyone interested in tackling this with me?

for debugging, i confined the changes to UIBarButtonItem.

![2013-07-31_23-22-22](https://f.cloud.github.com/assets/466104/890122/e952f0d6-fa2c-11e2-8f15-a0102176d725.png)
