### PR TITLE
Border implementation on FUISegmentedControl iOS 7 style

### DIFF
--- a/Classes/ios/FUISegmentedControl.h
+++ b/Classes/ios/FUISegmentedControl.h
@@ -20,6 +20,7 @@
 @property(nonatomic, strong, readwrite) UIColor *deselectedFontColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, readwrite) UIColor *borderColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, readwrite) CGFloat borderWidth UI_APPEARANCE_SELECTOR;
+@property(nonatomic, readwrite) BOOL needsLayoutSubviews UI_APPEARANCE_SELECTOR;
 
 
 

--- a/Classes/ios/FUISegmentedControl.m
+++ b/Classes/ios/FUISegmentedControl.m
@@ -25,6 +25,21 @@
     }
 }
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    if(self.needsLayoutSubviews) {
+        UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+        
+        if (UI_USER_INTERFACE_IDIOM()== UIUserInterfaceIdiomPhone && UIInterfaceOrientationIsLandscape(orientation)) {
+            self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, self.frame.size.width, 22);
+        } else {
+            self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, self.frame.size.width, 30);
+        }
+    }
+}
+
 - (void)setDeselectedColor:(UIColor *)deselectedColor {
     _deselectedColor = deselectedColor;
     [self configureFlatSegmentedControl];


### PR DESCRIPTION
I have implemented border on FUISegmentedControl see the example:

FUISegmentedControl *segmentedControl = [[FUISegmentedControl alloc] initWithItems:[NSArray arrayWithObjects:@"Loja", @"Compradas", nil]];
    segmentedControl.frame = CGRectMake(0, 0, 160, 30);
    segmentedControl.selectedFont = [UIFont boldFlatFontOfSize:13];
    segmentedControl.selectedFontColor = [UIColor colorWithRed:31/255.0 green:34/255.0 blue:36/255.0 alpha:1.0];
    segmentedControl.deselectedFont = [UIFont flatFontOfSize:13];
    segmentedControl.deselectedFontColor = [UIColor colorWithRed:228/255.0 green:228/255.0 blue:228/255.0 alpha:1.0];
    segmentedControl.selectedColor = [UIColor colorWithRed:228/255.0 green:228/255.0 blue:228/255.0 alpha:1.0];
    segmentedControl.deselectedColor = [UIColor colorWithRed:31/255.0 green:34/255.0 blue:36/255.0 alpha:1.0];
_//    segmentedControl.dividerColor = [UIColor redColor];_
    segmentedControl.cornerRadius = 5.0;
    **segmentedControl.borderWidth = 1.0;**
    **segmentedControl.borderColor = [UIColor colorWithRed:228/255.0 green:228/255.0 blue:228/255.0 alpha:1.0];**
![foto-1](https://f.cloud.github.com/assets/103670/911760/32683ccc-fdf2-11e2-91df-e78255c16458.png)
Now if you don't set dividerColor automatically is selected and unselected colors.

If using needsLayoutSubviews YES auto adjust height on iPhone
**segmentedControl.needsLayoutSubviews = YES;**
![foto-2](https://f.cloud.github.com/assets/103670/911786/b60cc14c-fdf2-11e2-9ddb-f4eb78f2442a.png)
