### PR TITLE
Changed the UITableViewCell class so that it uses the dequeueReusableCel...

### DIFF
--- a/Classes/ios/UITableViewCell+FlatUI.h
+++ b/Classes/ios/UITableViewCell+FlatUI.h
@@ -13,7 +13,7 @@
 @property (nonatomic) CGFloat cornerRadius;
 @property (nonatomic) CGFloat separatorHeight;
 
-+ (UITableViewCell*) configureFlatCellWithColor:(UIColor *)color selectedColor:(UIColor *)selectedColor style:(UITableViewCellStyle)style reuseIdentifier:(NSString*)reuseIdentifier;
++ (UITableViewCell*) configureFlatCellWithColor:(UIColor *)color selectedColor:(UIColor *)selectedColor reuseIdentifier:(NSString*)reuseIdentifier inTableView:(UITableView *)tableView;
 
 - (void) configureFlatCellWithColor:(UIColor *)color selectedColor:(UIColor *)selectedColor;
 

--- a/Classes/ios/UITableViewCell+FlatUI.m
+++ b/Classes/ios/UITableViewCell+FlatUI.m
@@ -14,8 +14,9 @@
 
 @dynamic cornerRadius, separatorHeight;
 
-+ (UITableViewCell*) configureFlatCellWithColor:(UIColor *)color selectedColor:(UIColor *)selectedColor style:(UITableViewCellStyle)style reuseIdentifier:(NSString*)reuseIdentifier {
-    UITableViewCell* cell = [[UITableViewCell alloc] initWithStyle:style reuseIdentifier:reuseIdentifier];
++ (UITableViewCell*) configureFlatCellWithColor:(UIColor *)color selectedColor:(UIColor *)selectedColor reuseIdentifier:(NSString*)reuseIdentifier inTableView:(UITableView *)tableView {
+    
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier];
     
     [cell configureFlatCellWithColor:color selectedColor:selectedColor];
     

--- a/README.markdown
+++ b/README.markdown
@@ -145,8 +145,8 @@ You can modify the backgroundColor and selectedBackgroundColor of a UITableViewC
 ```objective-c
 cell = [UITableViewCell configureFlatCellWithColor:[UIColor greenSeaColor]
                                      selectedColor:[UIColor cloudsColor]
-                                             style:UITableViewCellStyleDefault
-                                   reuseIdentifier:CellIdentifier];
+                                   reuseIdentifier:CellIdentifier
+                                   inTableView:tableView];
 cell.cornerRadius = 5.0f; // optional
 cell.separatorHeight = 2.0f; // optional
 ```


### PR DESCRIPTION
Changed the UITableViewCell class so that it uses the dequeueReusableCellWithIdentifier instead of alloc initing a new cell. This fixes a bug that made table view selection not work, and also improves performance for larger tableviews. The documentation was updated to reflect this change.
