### PR TITLE
Fixed a memory leak in UIImage+FlatUI.m

### DIFF
--- a/Classes/ios/UIImage+FlatUI.m
+++ b/Classes/ios/UIImage+FlatUI.m
@@ -53,6 +53,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
                                                      cornerRadius + shadowInsets.left,
                                                      cornerRadius + shadowInsets.bottom,
                                                      cornerRadius + shadowInsets.right);
+    UIGraphicsEndImageContext();
     return [buttonImage resizableImageWithCapInsets:resizeableInsets];
     
 }
@@ -77,6 +78,7 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     UIGraphicsBeginImageContextWithOptions(CGSizeMake(size.width, size.height), NO, 0.0f);
     [self drawInRect:rect];
     UIImage *resized = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
     return [resized resizableImageWithCapInsets:UIEdgeInsetsMake(size.height/2, size.width/2, size.height/2, size.width/2)];
 }
 


### PR DESCRIPTION
Two functions were not calling UIGraphicsEndImageContext() in the UIImage+FlatUI.m class. All the others ones were, so it made me suspicious.

ARC does not seem to be able to autorelease any buttons created with these classes, as the context is never closed, and thus a small memory leak is introduced when navigating through view controllers. I found that simply inserting these two function calls plugged the leak.
