### PR TITLE
Fixed example project, issue with cornerRadius and separatorHeight.

### DIFF
--- a/Example/FlatUIKitExample/TableViewController.m
+++ b/Example/FlatUIKitExample/TableViewController.m
@@ -63,13 +63,15 @@
     if (!cell) {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
         [cell configureFlatCellWithColor:[UIColor greenSeaColor] selectedColor:[UIColor cloudsColor]];
-        cell.cornerRadius = 5.f; //Optional
-        if (self.tableView.style == UITableViewStyleGrouped) {
-            cell.separatorHeight = 2.f; //Optional            
-        }
-        else {
-            cell.separatorHeight = 0.;
-        }
+    }
+    
+    cell.cornerRadius = 5.f; //Optional
+    
+    if (self.tableView.style == UITableViewStyleGrouped) {
+        cell.separatorHeight = 2.f; //Optional
+    }
+    else {
+        cell.separatorHeight = 0.;
     }
     
     cell.textLabel.text = [NSString stringWithFormat:@"Section %d Row %d", indexPath.section, indexPath.row];


### PR DESCRIPTION
Fixed example project, where UITableView cornerRadius and separatorHeight assigned incorrectly.

When UITableView first time loaded, cornerRadius and separatorHeight is
drawn correct. But, when you scroll down and force UITableViewCell
redraw, cornerRadius and separatorHeight is set to initial values from
initialize method.  Maybe it's because of defective implementation in
FUICellBackgroundView or UITableViewCell+FlatUI ?! At least this commit
fixes the example project demonstration correctly.
