### PR TITLE
Fixed crash on iOS <7

### DIFF
--- a/Classes/ios/FUIAlertView.m
+++ b/Classes/ios/FUIAlertView.m
@@ -170,7 +170,7 @@
     CGFloat titleHeight;
     CGFloat messageHeight;
     
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_7_0
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending) {
         // iOS7 methods
         CGRect titleRect = [self.titleLabel.text boundingRectWithSize:CGSizeMake(contentWidth, CGFLOAT_MAX)
                                                               options:NSStringDrawingUsesLineFragmentOrigin
@@ -182,12 +182,12 @@
                                                                   context:nil];
         titleHeight = titleRect.size.height;
         messageHeight = messageRect.size.height;
-#else
+    } else {
         // Pre-iOS7 methods
         titleHeight = [self.titleLabel.text sizeWithFont:self.titleLabel.font constrainedToSize:CGSizeMake(contentWidth, CGFLOAT_MAX)].height;
         messageHeight = [self.messageLabel.text sizeWithFont:self.messageLabel.font constrainedToSize:CGSizeMake(contentWidth, CGFLOAT_MAX)].height;
-#endif
-    
+    }
+
     CGFloat buttonHeight = [self totalButtonHeight];
     CGFloat contentHeight = titleHeight + 10 + messageHeight + 10 + buttonHeight;
     if(self.maxHeight && contentHeight>self.maxHeight)

--- a/Classes/ios/FUISegmentedControl.m
+++ b/Classes/ios/FUISegmentedControl.m
@@ -68,23 +68,20 @@
 - (void)setupFonts {
     
     NSDictionary *selectedAttributesDictionary;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
-        // iOS6 methods
-        if (1 == 1) {
-            NSShadow *shadow = [[NSShadow alloc] init];
-            [shadow setShadowOffset:CGSizeZero];
-            [shadow setShadowColor:[UIColor clearColor]];
-            selectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-                                            self.selectedFontColor,
-                                            NSForegroundColorAttributeName,
-                                            shadow,
-                                            NSShadowAttributeName,
-                                            self.selectedFont,
-                                            NSFontAttributeName,
-                                            nil];
-        }
-
-#else
+    
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
+        NSShadow *shadow = [[NSShadow alloc] init];
+        [shadow setShadowOffset:CGSizeZero];
+        [shadow setShadowColor:[UIColor clearColor]];
+        selectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
+                                        self.selectedFontColor,
+                                        NSForegroundColorAttributeName,
+                                        shadow,
+                                        NSShadowAttributeName,
+                                        self.selectedFont,
+                                        NSFontAttributeName,
+                                        nil];
+    } else {
         // Pre-iOS6 methods
         selectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
                                         self.selectedFontColor,
@@ -96,13 +93,13 @@
                                         self.selectedFont,
                                         UITextAttributeFont,
                                         nil];
-#endif
+    }
     
     [self setTitleTextAttributes:selectedAttributesDictionary forState:UIControlStateSelected];
     
     NSDictionary *deselectedAttributesDictionary;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
-        // iOS6 methods
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
+        // iOS6+ methods
         NSShadow *shadow = [[NSShadow alloc] init];
         [shadow setShadowOffset:CGSizeZero];
         [shadow setShadowColor:[UIColor clearColor]];
@@ -114,8 +111,8 @@
                                           self.deselectedFont,
                                           NSFontAttributeName,
                                           nil];
-#else
-        // Pre-iOS6 methods
+    } else {
+        // pre-iOS6 methods
         deselectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
                                           self.deselectedFontColor,
                                           UITextAttributeTextColor,
@@ -126,7 +123,8 @@
                                           self.deselectedFont,
                                           UITextAttributeFont,
                                           nil];
-#endif
+    }
+
     [self setTitleTextAttributes:deselectedAttributesDictionary forState:UIControlStateNormal];
 }
 

--- a/Classes/ios/UIBarButtonItem+FlatUI.m
+++ b/Classes/ios/UIBarButtonItem+FlatUI.m
@@ -44,18 +44,18 @@
         if (!titleTextAttributes) {
             titleTextAttributes = [NSMutableDictionary dictionary];
         }
-        
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
-            // iOS6 methods
+
+        if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
+            // iOS6+ methods
             NSShadow *shadow = [[NSShadow alloc] init];
             [shadow setShadowOffset:CGSizeZero];
             [shadow setShadowColor:[UIColor clearColor]];
             [titleTextAttributes setObject:shadow forKey:NSShadowAttributeName];
-#else
+        } else {
             // Pre-iOS6 methods
             [titleTextAttributes setValue:[UIColor clearColor] forKey:UITextAttributeTextShadowColor];
             [titleTextAttributes setValue:[NSValue valueWithUIOffset:UIOffsetZero] forKey:UITextAttributeTextShadowOffset];
-#endif
+        }
         
         [self setTitleTextAttributes:titleTextAttributes forState:controlState];
     }

--- a/Classes/ios/UINavigationBar+FlatUI.m
+++ b/Classes/ios/UINavigationBar+FlatUI.m
@@ -19,17 +19,18 @@
         titleTextAttributes = [NSMutableDictionary dictionary];
     }
     
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
         // iOS6 methods
         NSShadow *shadow = [[NSShadow alloc] init];
         [shadow setShadowOffset:CGSizeZero];
         [shadow setShadowColor:[UIColor clearColor]];
         [titleTextAttributes setObject:shadow forKey:NSShadowAttributeName];
-#else
+    } else {
         // Pre-iOS6 methods
         [titleTextAttributes setValue:[UIColor clearColor] forKey:UITextAttributeTextShadowColor];
         [titleTextAttributes setValue:[NSValue valueWithUIOffset:UIOffsetZero] forKey:UITextAttributeTextShadowOffset];
-#endif
+
+    }
     
     [self setTitleTextAttributes:titleTextAttributes];
     if ([self respondsToSelector:@selector(setShadowImage:)]) {


### PR DESCRIPTION
So last night I was thinking to myself "pre-compiler OS version checks don't make any sense…". Today I tested it and I was correct, my pre-compiler checks always evaluated to TRUE (i.e. the OS was always > 7.0). This caused a crash on iOS 5 and 6. This pull request fixes that. 

Seriously – I really apologise for not checking thoroughly.
