### PR TITLE
Optimised UIFont rendering

### DIFF
--- a/Classes/ios/UIFont+FlatUI.m
+++ b/Classes/ios/UIFont+FlatUI.m
@@ -12,36 +12,51 @@
 @implementation UIFont (FlatUI)
 
 + (UIFont *)flatFontOfSize:(CGFloat)size {
+    static UIFont          *flatFont = nil;
     static dispatch_once_t onceToken;
+    
     dispatch_once(&onceToken, ^{
         NSURL * url = [[NSBundle mainBundle] URLForResource:@"Lato-Regular" withExtension:@"ttf"];
 		CFErrorRef error;
         CTFontManagerRegisterFontsForURL((__bridge CFURLRef)url, kCTFontManagerScopeNone, &error);
         error = nil;
+        
+        flatFont = [UIFont fontWithName:@"Lato-Regular" size:size];
     });
-    return [UIFont fontWithName:@"Lato-Regular" size:size];
+    
+    return flatFont;
 }
 
 + (UIFont *)boldFlatFontOfSize:(CGFloat)size {
+    static UIFont *boldFont = nil;
     static dispatch_once_t onceToken;
+    
     dispatch_once(&onceToken, ^{
         NSURL * url = [[NSBundle mainBundle] URLForResource:@"Lato-Bold" withExtension:@"ttf"];
 		CFErrorRef error;
         CTFontManagerRegisterFontsForURL((__bridge CFURLRef)url, kCTFontManagerScopeNone, &error);
         error = nil;
+        
+        boldFont = [UIFont fontWithName:@"Lato-Bold" size:size];
     });
-    return [UIFont fontWithName:@"Lato-Bold" size:size];
+
+    return boldFont;
 }
 
 + (UIFont *)italicFlatFontOfSize:(CGFloat)size {
+    static UIFont          *italicFont = nil;
     static dispatch_once_t onceToken;
+    
     dispatch_once(&onceToken, ^{
         NSURL * url = [[NSBundle mainBundle] URLForResource:@"Lato-Italic" withExtension:@"ttf"];
 		CFErrorRef error;
         CTFontManagerRegisterFontsForURL((__bridge CFURLRef)url, kCTFontManagerScopeNone, &error);
         error = nil;
+        
+        italicFont = [UIFont fontWithName:@"Lato-Italic" size:size];
     });
-    return [UIFont fontWithName:@"Lato-Italic" size:size];
+    
+    return italicFont;
 }
 
 @end


### PR DESCRIPTION
Rearranged the dispatch_once approach being used to include the rendering of the UIFont instance.

Before this, fonts would take roughly 0.015510 seconds to render the first time, then 0.000050 seconds the render for subsequent times. After this change, subsequent renders now only take roughly 0.000015. 

Speed tested on an iPhone 5.
