### PR TITLE
Add the option to set the disabledColor of an FUIButton

### DIFF
--- a/Classes/ios/FUIButton.h
+++ b/Classes/ios/FUIButton.h
@@ -13,6 +13,8 @@
 @property(nonatomic, strong, readwrite) UIColor *buttonColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, readwrite) UIColor *shadowColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong, readwrite) UIColor *highlightedColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, readwrite) UIColor *disabledColor UI_APPEARANCE_SELECTOR;
+@property(nonatomic, strong, readwrite) UIColor *disabledShadowColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, readwrite) CGFloat shadowHeight UI_APPEARANCE_SELECTOR;
 @property(nonatomic, readwrite) CGFloat cornerRadius UI_APPEARANCE_SELECTOR;
 

--- a/Classes/ios/FUIButton.m
+++ b/Classes/ios/FUIButton.m
@@ -52,8 +52,18 @@
     [self configureFlatButton];
 }
 
-- (void) setHighlightedColor:(UIColor *)highlightedColor{
+- (void) setHighlightedColor:(UIColor *)highlightedColor {
     _highlightedColor = highlightedColor;
+    [self configureFlatButton];
+}
+
+- (void) setDisabledColor:(UIColor *)disabledColor {
+    _disabledColor = disabledColor;
+    [self configureFlatButton];
+}
+
+- (void) setDisabledShadowColor:(UIColor *)disabledShadowColor {
+    _disabledShadowColor = disabledShadowColor;
     [self configureFlatButton];
 }
 
@@ -73,13 +83,22 @@
                                                       cornerRadius:self.cornerRadius
                                                        shadowColor:self.shadowColor
                                                       shadowInsets:UIEdgeInsetsMake(0, 0, self.shadowHeight, 0)];
-    
-    UIColor *color = self.highlightedColor == nil ? self.buttonColor : self.highlightedColor;
-    UIImage *highlightedBackgroundImage = [UIImage buttonImageWithColor:color
+
+    UIColor *highlightedColor = self.highlightedColor == nil ? self.buttonColor : self.highlightedColor;
+    UIImage *highlightedBackgroundImage = [UIImage buttonImageWithColor:highlightedColor
                                                            cornerRadius:self.cornerRadius
                                                             shadowColor:[UIColor clearColor]
                                                            shadowInsets:UIEdgeInsetsMake(self.shadowHeight, 0, 0, 0)];
-    
+
+    if (self.disabledColor) {
+        UIColor *disabledShadowColor = self.disabledShadowColor == nil ? self.shadowColor : self.disabledShadowColor;
+        UIImage *disabledBackgroundImage = [UIImage buttonImageWithColor:self.disabledColor
+                                                            cornerRadius:self.cornerRadius
+                                                             shadowColor:disabledShadowColor
+                                                            shadowInsets:UIEdgeInsetsMake(0, 0, self.shadowHeight, 0)];
+        [self setBackgroundImage:disabledBackgroundImage forState:UIControlStateDisabled];
+    }
+
     [self setBackgroundImage:normalBackgroundImage forState:UIControlStateNormal];
     [self setBackgroundImage:highlightedBackgroundImage forState:UIControlStateHighlighted];
 }


### PR DESCRIPTION
Add the option to set the `disabledColor` (and `disabledShadowColor`) of an `FUIButton`.
- If the `disabledColor` is not set, do nothing and allow the default behaviour of `adjustsImageWhenDisabled` to happen.
- If `disabledColor` is set but `disabledShadowColor` is not, `disabledShadowColor` defaults to `shadowColor`.
- If `disabledColor` is not set, setting `disabledShadowColor` has no effect.

(Similar to [pull request #121](https://github.com/Grouper/FlatUIKit/pull/121) - Add the option to assign a highlightedColor to FUIButton)
