### PR TITLE
Fix for FUISwitch color issue in iOS 7.1. Corrected peterRiverColor hex code.

### DIFF
--- a/Classes/ios/UIColor+FlatUI.m
+++ b/Classes/ios/UIColor+FlatUI.m
@@ -258,19 +258,17 @@
                               backgroundColor:(UIColor *)backgroundColor
                                  percentBlend:(CGFloat) percentBlend {
     CGFloat onRed, offRed, newRed, onGreen, offGreen, newGreen, onBlue, offBlue, newBlue, onWhite, offWhite;
-    if ([foregroundColor getWhite:&onWhite alpha:nil]) {
+    if (![foregroundColor getRed:&onRed green:&onGreen blue:&onBlue alpha:nil]) {
+        [foregroundColor getWhite:&onWhite alpha:nil];
         onRed = onWhite;
         onBlue = onWhite;
         onGreen = onWhite;
-    } else {
-        [foregroundColor getRed:&onRed green:&onGreen blue:&onBlue alpha:nil];
     }
-    if ([backgroundColor getWhite:&offWhite alpha:nil]) {
+    if (![backgroundColor getRed:&offRed green:&offGreen blue:&offBlue alpha:nil]) {
+        [backgroundColor getWhite:&offWhite alpha:nil];
         offRed = offWhite;
         offBlue = offWhite;
         offGreen = offWhite;
-    } else {
-        [backgroundColor getRed:&offRed green:&offGreen blue:&offBlue alpha:nil];
     }
     newRed = onRed * percentBlend + offRed * (1-percentBlend);
     newGreen = onGreen * percentBlend + offGreen * (1-percentBlend);


### PR DESCRIPTION
Fix for FUISwitch color issue in iOS 7.1 
Issue:
Method was blending colors taking grayscale components first.
Fix:
Changed the order of the calls to convert the colors. First check if it
is possible to get the components in RGB. As last resort, go with
grayscale values.

Corrected peterRiverColor hex code.
Hex code for peterRiverColor was the same as nephritisColor hex code.
Changed peterRiverColor to the correct one according to the web
http://flatuicolors.com.
