### PR TITLE
FUISegmentedControl deselected text color not applied on iOS 6

### DIFF
--- a/Classes/ios/FUISegmentedControl.m
+++ b/Classes/ios/FUISegmentedControl.m
@@ -90,10 +90,14 @@
 }
 
 - (void)setupFonts {
-    
+	// Although iOS 6 supports NSForegroundColorAttributeName,
+	// it doesn't seem to apply it to deselected segments but will apply the
+	// old UITextAttributeTextColor attribute. We therefore do a runtime version
+	// check and use the old attributes when needed
+
     NSDictionary *selectedAttributesDictionary;
     
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
+	if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) {
         NSShadow *shadow = [[NSShadow alloc] init];
         [shadow setShadowOffset:CGSizeZero];
         [shadow setShadowColor:[UIColor clearColor]];
@@ -106,7 +110,7 @@
                                         NSFontAttributeName,
                                         nil];
     } else {
-        // Pre-iOS6 methods
+        // iOS6- methods
         selectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
                                         self.selectedFontColor,
                                         UITextAttributeTextColor,
@@ -122,7 +126,7 @@
     [self setTitleTextAttributes:selectedAttributesDictionary forState:UIControlStateSelected];
     
     NSDictionary *deselectedAttributesDictionary;
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending) {
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) {
         // iOS7+ methods
         NSShadow *shadow = [[NSShadow alloc] init];
         [shadow setShadowOffset:CGSizeZero];
@@ -135,23 +139,8 @@
                                           self.deselectedFont,
                                           NSFontAttributeName,
                                           nil];
-    } else if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
-        // iOS6 methods. Although iOS 6 supports NSForegroundColorAttributeName,
-		// it doesn't seem to apply it to deselected segments but will apply the
-		// old UITextAttributeTextColor attribute
-        NSShadow *shadow = [[NSShadow alloc] init];
-        [shadow setShadowOffset:CGSizeZero];
-        [shadow setShadowColor:[UIColor clearColor]];
-        deselectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-                                          self.deselectedFontColor,
-                                          UITextAttributeTextColor,
-                                          shadow,
-                                          NSShadowAttributeName,
-                                          self.deselectedFont,
-                                          NSFontAttributeName,
-                                          nil];
-    } else {
-        // pre-iOS6 methods
+	} else {
+        // iOS6- methods.
         deselectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
                                           self.deselectedFontColor,
                                           UITextAttributeTextColor,
@@ -166,8 +155,8 @@
     [self setTitleTextAttributes:deselectedAttributesDictionary forState:UIControlStateNormal];
 
     NSDictionary *disabledAttributesDictionary;
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
-        // iOS6+ methods
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) {
+        // iOS7+ methods
         NSShadow *shadow = [[NSShadow alloc] init];
         [shadow setShadowOffset:CGSizeZero];
         [shadow setShadowColor:[UIColor clearColor]];
@@ -180,7 +169,7 @@
                 NSFontAttributeName,
                 nil];
     } else {
-        // pre-iOS6 methods
+        // iOS6- methods
         disabledAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
                 self.disabledFontColor,
                 UITextAttributeTextColor,

--- a/Classes/ios/FUISegmentedControl.m
+++ b/Classes/ios/FUISegmentedControl.m
@@ -122,14 +122,29 @@
     [self setTitleTextAttributes:selectedAttributesDictionary forState:UIControlStateSelected];
     
     NSDictionary *deselectedAttributesDictionary;
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
-        // iOS6+ methods
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending) {
+        // iOS7+ methods
         NSShadow *shadow = [[NSShadow alloc] init];
         [shadow setShadowOffset:CGSizeZero];
         [shadow setShadowColor:[UIColor clearColor]];
         deselectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
                                           self.deselectedFontColor,
                                           NSForegroundColorAttributeName,
+                                          shadow,
+                                          NSShadowAttributeName,
+                                          self.deselectedFont,
+                                          NSFontAttributeName,
+                                          nil];
+    } else if ([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending) {
+        // iOS6 methods. Although iOS 6 supports NSForegroundColorAttributeName,
+		// it doesn't seem to apply it to deselected segments but will apply the
+		// old UITextAttributeTextColor attribute
+        NSShadow *shadow = [[NSShadow alloc] init];
+        [shadow setShadowOffset:CGSizeZero];
+        [shadow setShadowColor:[UIColor clearColor]];
+        deselectedAttributesDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
+                                          self.deselectedFontColor,
+                                          UITextAttributeTextColor,
                                           shadow,
                                           NSShadowAttributeName,
                                           self.deselectedFont,

--- a/Classes/ios/UIBarButtonItem+FlatUI.m
+++ b/Classes/ios/UIBarButtonItem+FlatUI.m
@@ -96,8 +96,6 @@
     UIImage *buttonImageHightlighted = [UIImage imageWithColor:highlightedColor cornerRadius:cornerRadius];
     [appearance setBackgroundImage:buttonImageNormal forState:UIControlStateNormal barMetrics:UIBarMetricsDefault];
     [appearance setBackgroundImage:buttonImageHightlighted forState:UIControlStateHighlighted barMetrics:UIBarMetricsDefault];
-    NSDictionary *attrs = [appearance titleTextAttributesForState:UIControlStateNormal];
-    [appearance setTitleTextAttributes:attrs forState:UIControlStateNormal];
 }
 
 @end


### PR DESCRIPTION
I have the following issue:
* on iOS 7 everything works as needed
* on iOS 6 the text color for deselected segments isn't being applied. When I changed the code for deselectedAttributesDictionary to include UITextAttributeTextColor instead of NSForegroundColorAttributeName, everything worked as meant to.

The fix is, I suppose, to add an extra case specifically for iOS 6, for deselected (normal) state, to use the old attribute instead of the new one. 