### PR TITLE
BUG FIX: Explicit #import UIKit framework

### DIFF
--- a/Classes/ios/FUICellBackgroundView.h
+++ b/Classes/ios/FUICellBackgroundView.h
@@ -5,6 +5,8 @@
 //  Created by Maciej Swic on 2013-05-30.
 //  Licensed under the MIT license.
 
+#import <UIKit/UIKit.h>
+
 @interface FUICellBackgroundView : UIView
 
 @property (nonatomic, strong) UIColor *backgroundColor UI_APPEARANCE_SELECTOR;

--- a/Classes/ios/UIToolbar+FlatUI.h
+++ b/Classes/ios/UIToolbar+FlatUI.h
@@ -5,7 +5,7 @@
 // To change the template use AppCode | Preferences | File Templates.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface UIToolbar (FlatUI)
 


### PR DESCRIPTION
`FUICellBackgroundView` and the `UIToolbar` category don't explicitly #import the UIKit framework. This causes problems for projects that don't have UIKit as part of the precompiled headers.
