### PR TITLE
Changed UIImage to fix backbutton distortion

### DIFF
--- a/Classes/ios/UIImage+FlatUI.m
+++ b/Classes/ios/UIImage+FlatUI.m
@@ -112,11 +112,8 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
                             barMetrics:(UIBarMetrics) metrics
                           cornerRadius:(CGFloat)cornerRadius {
     CGSize size;
-    if (metrics == UIBarMetricsDefault) {
-        size = CGSizeMake(50, 30);
-    } else {
-        size = CGSizeMake(60, 23);
-    }
+    size = CGSizeMake(50, 27);
+
     UIBezierPath *path = [self bezierPathForBackButtonInRect:CGRectMake(0, 0, size.width, size.height) cornerRadius:cornerRadius];
     UIGraphicsBeginImageContextWithOptions(size, NO, 0.0f);
     [color setFill];


### PR DESCRIPTION
![screen shot 2014-05-27 at 7 32 07 pm](https://cloud.githubusercontent.com/assets/6572139/3149680/882c9d20-ea6d-11e3-8f36-5d2d167aa10f.png)
![screen shot 2014-05-27 at 7 17 07 pm](https://cloud.githubusercontent.com/assets/6572139/3149683/8b597ce8-ea6d-11e3-9a8a-281887d351de.png)

I saw this bug in the example project, when you rotate the screen the button becomes distorted. It appears to be a view did load issue, where the view is not being refreshed upon rotation. I've tried experimenting with didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation method in tableviewcontroller, but it still does not refresh the view.

So in the mean time I removed the if statement in UIImage's backButtonImageWithColor method and set the button to be uniformly the same size regardless what orientation it is in. This is just meant to be a temporarily fix to relieve the distortion issue until a more permanent solution can be created.