### PR TITLE
iOS7 Backbutton fix this commit fixes #150

### DIFF
--- a/Classes/ios/UIImage+FlatUI.m
+++ b/Classes/ios/UIImage+FlatUI.m
@@ -124,8 +124,12 @@ static CGFloat edgeSizeFromCornerRadius(CGFloat cornerRadius) {
     [path fill];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
-    return [image resizableImageWithCapInsets:UIEdgeInsetsMake(cornerRadius, 15, cornerRadius, cornerRadius)];
-    
+	
+	if ([image respondsToSelector:@selector(resizableImageWithCapInsets:resizingMode:)]) {
+		return [image resizableImageWithCapInsets:UIEdgeInsetsMake(cornerRadius, 15, cornerRadius, cornerRadius) resizingMode:UIImageResizingModeStretch];
+	}else{
+		return [image resizableImageWithCapInsets:UIEdgeInsetsMake(cornerRadius, 15, cornerRadius, cornerRadius)];
+	}
 }
 
 + (UIBezierPath *) bezierPathForBackButtonInRect:(CGRect)rect cornerRadius:(CGFloat)radius {


### PR DESCRIPTION
on iOS7 use resizableImageWithCapInsets:resizingMode: to make sure the
button sizes correctly in landscape..

This still insures that the button size is different for landscape or port.. 

fixes #150 