### PR TITLE
ios7.1 color fixes for Stepper/Progressview

### DIFF
--- a/Classes/ios/UIProgressView+FlatUI.m
+++ b/Classes/ios/UIProgressView+FlatUI.m
@@ -11,14 +11,24 @@
 @implementation UIProgressView (FlatUI)
 
 - (void)configureFlatProgressViewWithTrackColor:(UIColor *)trackColor {
-    UIImage *trackImage = [UIImage imageWithColor:trackColor cornerRadius:4.0];
+	UIImage *trackImage = [UIImage imageWithColor:trackColor cornerRadius:4.0];
     trackImage = [trackImage imageWithMinimumSize:CGSizeMake(10.0f, 10.0f)];
     [self setTrackImage:trackImage];
+
+	if ([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending) {
+		[self setTintColor:trackColor];
+	}
+
 }
 
 - (void)configureFlatProgressViewWithProgressColor:(UIColor *)progressColor {
     UIImage *progressImage = [UIImage imageWithColor:progressColor cornerRadius:4.0];
     [self setProgressImage:progressImage];
+	
+	if ([[[UIDevice currentDevice] systemVersion] compare:@"7.1" options:NSNumericSearch] != NSOrderedAscending) {
+		[self setTintColor:progressColor];
+	}
+
 }
 
 - (void) configureFlatProgressViewWithTrackColor:(UIColor *)trackColor

--- a/Classes/ios/UIStepper+FlatUI.m
+++ b/Classes/ios/UIStepper+FlatUI.m
@@ -42,6 +42,11 @@
         [self setDecrementImage:minusImage forState:UIControlStateNormal];
         [self setDecrementImage:minusImage forState:UIControlStateDisabled];
     }
+	
+	if ([[[UIDevice currentDevice] systemVersion] compare:@"7.1" options:NSNumericSearch] != NSOrderedAscending) {
+		[self setTintColor:iconColor];
+	}
+
 }
 
 @end


### PR DESCRIPTION
fixes the Stepper to tint color of the +/-
The progress bar image is broken for 7.1 (http://openradar.io/16113307)

for now the only other workaround is to roll own version.. 
http://stackoverflow.com/questions/22311516/uiprogressview-custom-track-and-progress-images-in-ios-7-1