### PR TITLE
Correctly propagate animated flag in FUISwitch setOn:animated:

### DIFF
--- a/Classes/ios/FUISwitch.m
+++ b/Classes/ios/FUISwitch.m
@@ -104,7 +104,7 @@
 }
 
 - (void)setOn:(BOOL)on animated:(BOOL)animated {
-    [self setOn:on animated:NO sendEvent:NO];
+    [self setOn:on animated:animated sendEvent:NO];
 }
 
 - (void)setOn:(BOOL)on animated:(BOOL)animated sendEvent:(BOOL)sendEvent {


### PR DESCRIPTION
This propagates the animated flag in FUISwitch correctly (see #177).