### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,13 +12,13 @@ FlatUIKit is a collection of iOS components styled with the "Flat UI" aesthetic 
 Installation
 -------
 
-FlatUIKit can be installed via [Cocoapods](http://cocoapods.org/). Simply add
+FlatUIKit can be installed via [CocoaPods](http://cocoapods.org/). Simply add
 
 ```ruby
 pod 'FlatUIKit'
 ```
 
-to your Podfile. If you don't use Cocoapods you're welcome to use git submodules, or simply [download it](https://github.com/Grouper/FlatUIKit/archive/master.zip) and include it in your project manually.
+to your Podfile. If you don't use CocoaPods you're welcome to use git submodules, or simply [download it](https://github.com/Grouper/FlatUIKit/archive/master.zip) and include it in your project manually.
 
 Note that FlatUIKit requires the CoreText framework as well as iOS > 6.0.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
